### PR TITLE
feat: blur assignment topbar

### DIFF
--- a/frontend/assignment.css
+++ b/frontend/assignment.css
@@ -111,9 +111,9 @@ body.bg-dark { background-color: transparent !important; }
 .assignment-topbar {
   position: sticky;
   padding: .5rem .75rem;
-  background: rgba(17,19,23,0.6);
-  backdrop-filter: saturate(120%) blur(8px);
-  -webkit-backdrop-filter: saturate(120%) blur(8px);
+  background: rgba(17,19,23,0.2);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   border-bottom: 1px solid rgba(255,255,255,0.06);
   border-top-left-radius: var(--radius);
   border-top-right-radius: var(--radius);


### PR DESCRIPTION
## Summary
- make assignment topbar more transparent and blur background so content below shows through

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `cd backend && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aaf407b690832fbf13bd1bf48c9686