### PR TITLE
Make page headers mobile-friendly

### DIFF
--- a/frontend/bookmarks.html
+++ b/frontend/bookmarks.html
@@ -125,7 +125,7 @@
     </nav>
 
     <div class="container">
-      <h1 class="text-center" style="padding-top: 3rem">QBase</h1>
+      <h1 class="text-center pt-3 pt-md-5 fs-2">QBase</h1>
       <h2 class="">Bookmarks</h2>
 
       <div id="loading" class="text-center py-5">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -103,8 +103,8 @@
 
     <!-- PAGE -->
     <div class="container">
-      <h1 class="text-center" style="padding-top: 3rem">QBase</h1>
-      <div class="d-flex justify-content-between pt-5">
+      <h1 class="text-center pt-3 pt-md-5 fs-2">QBase</h1>
+      <div class="d-flex flex-wrap align-items-center justify-content-between pt-3 pt-md-5 gap-3">
       <h2 class="">Assignments</h2>
 
       <div

--- a/frontend/worksheet_index.html
+++ b/frontend/worksheet_index.html
@@ -108,9 +108,9 @@
     <!-- PAGE -->
     <div class="container">
 
-      <h1 class="text-center" style="padding-top: 3rem;">QBase</h1>
+      <h1 class="text-center pt-3 pt-md-5 fs-2">QBase</h1>
 
-      <div class="d-flex justify-content-between pt-5">
+      <div class="d-flex flex-wrap align-items-center justify-content-between pt-3 pt-md-5 gap-3">
 
         <h2 class="">Worksheets</h2>
 


### PR DESCRIPTION
## Summary
- Prevent search bars from crowding page titles on the assignments and worksheets indexes by adding flex wrap and gap utilities.
- Shrink the "QBase" page heading on mobile by using smaller font sizing and reducing top padding.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf4b77e68832fa2a8ebc86609c245