### PR TITLE
Implement global search and expandable navbar input

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -57,6 +57,24 @@ h4 {
   color: #9aa3ac;
 }
 
+/* navbar search expansion */
+#navbar-search-input {
+  width: 8rem;
+  max-width: 100%;
+  transition: width 0.3s ease;
+}
+#navbar-search-input:focus {
+  width: 16rem;
+}
+@media (max-width: 576px) {
+  #navbar-search-input {
+    width: 6rem;
+  }
+  #navbar-search-input:focus {
+    width: 100%;
+  }
+}
+
 /* === subject + chapter groups === */
 .as-subject {
   margin-top: 1.25rem;

--- a/frontend/navbar.js
+++ b/frontend/navbar.js
@@ -500,8 +500,8 @@
     const input = document.getElementById("navbar-search-input");
     const query = (input?.value || "").trim();
 
-    // Always redirect to index.html with ?q= parameter
-    const url = new URL("./index.html", window.location.href);
+    // Redirect to global search results page with ?q= parameter
+    const url = new URL("./search.html", window.location.href);
     if (query) {
       url.searchParams.set("q", query);
     } else {

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>QBase – Search</title>
+
+    <!-- Bootstrap + Icons -->
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css"
+    />
+
+    <!-- Site styles -->
+    <link href="./index.css" rel="stylesheet" />
+
+    <!-- Site scripts -->
+    <script src="config.js"></script>
+    <script defer src="./navbar.js"></script>
+    <script defer src="./search.js"></script>
+  </head>
+  <body class="bg-dark text-light">
+    <!-- NAVBAR -->
+    <nav class="navbar navbar-expand-lg bg-body-tertiary">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="./index.html">QBase</a>
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navbarSupportedContent"
+          aria-controls="navbarSupportedContent"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item">
+              <a class="nav-link" aria-current="page" href="./index.html"
+                >Home</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="./bookmarks.html">Bookmarks</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="./worksheet_index.html">Worksheets</a>
+            </li>
+            <li class="nav-item" id="nav-login-item">
+              <a class="nav-link" href="#" id="nav-login">Login</a>
+            </li>
+            <li class="nav-item dropdown d-none" id="nav-user-item">
+              <a
+                class="nav-link dropdown-toggle"
+                href="#"
+                id="navbarUserDropdown"
+                role="button"
+                data-bs-toggle="dropdown"
+                aria-expanded="false"
+                ><span id="nav-username">User</span></a
+              >
+              <ul class="dropdown-menu" aria-labelledby="navbarUserDropdown">
+                <li>
+                  <a class="dropdown-item" href="#" id="nav-logout">Logout</a>
+                </li>
+                <li><hr class="dropdown-divider" /></li>
+                <li>
+                  <a
+                    class="dropdown-item text-danger"
+                    href="#"
+                    id="nav-delete-account"
+                    >Delete Account…</a
+                  >
+                </li>
+              </ul>
+            </li>
+          </ul>
+          <form class="d-flex" role="search" onsubmit="return false;">
+            <input
+              class="form-control me-2"
+              type="search"
+              placeholder="Search"
+              aria-label="Search"
+              id="navbar-search-input"
+            />
+            <button
+              class="btn btn-outline-success"
+              type="submit"
+              id="navbar-search-btn"
+            >
+              Search
+            </button>
+          </form>
+        </div>
+      </div>
+    </nav>
+
+    <!-- PAGE -->
+    <div class="container py-4">
+      <h1>Search Results</h1>
+
+      <div id="results-assignments" class="mt-4">
+        <h4>Assignments</h4>
+        <div id="assignment-results" class="list-group"></div>
+        <p id="assignment-empty" class="text-muted d-none">No assignments found</p>
+      </div>
+
+      <div id="results-worksheets" class="mt-5">
+        <h4>Worksheets</h4>
+        <div id="worksheet-results" class="list-group"></div>
+        <p id="worksheet-empty" class="text-muted d-none">No worksheets found</p>
+      </div>
+    </div>
+
+    <!-- Bootstrap JS -->
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"
+      crossorigin="anonymous"
+    ></script>
+  </body>
+</html>
+

--- a/frontend/search.js
+++ b/frontend/search.js
@@ -1,0 +1,143 @@
+"use strict";
+(async function () {
+  const params = new URLSearchParams(window.location.search);
+  const qRaw = params.get("q") || "";
+  const query = qRaw.trim().toLowerCase();
+
+  document.title = qRaw ? `Search – ${qRaw}` : "QBase – Search";
+
+  const els = {
+    aList: document.getElementById("assignment-results"),
+    aEmpty: document.getElementById("assignment-empty"),
+    wList: document.getElementById("worksheet-results"),
+    wEmpty: document.getElementById("worksheet-empty"),
+  };
+
+  try {
+    const [aData, wData] = await Promise.all([
+      fetch("./data/assignment_list.json").then((r) => r.json()).catch(() => []),
+      fetch("./data/worksheets/worksheet_list.json")
+        .then((r) => r.json())
+        .catch(() => []),
+    ]);
+
+    const assignments = Array.isArray(aData) ? aData : [];
+    const worksheets = normalizeWorksheets(wData);
+
+    renderAssignments(filterAssignments(assignments, query));
+    renderWorksheets(filterWorksheets(worksheets, query));
+  } catch (err) {
+    console.error("Search failed:", err);
+    els.aEmpty.classList.remove("d-none");
+    els.wEmpty.classList.remove("d-none");
+  }
+
+  function filterAssignments(list, q) {
+    if (!q) return list;
+    return list.filter((it) => {
+      const hay = [
+        it.title,
+        it.subject,
+        it.chapter,
+        it.faculty,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return hay.includes(q);
+    });
+  }
+
+  function renderAssignments(list) {
+    if (list.length === 0) {
+      els.aEmpty.classList.remove("d-none");
+      return;
+    }
+    list.forEach((it) => {
+      const a = document.createElement("a");
+      a.className = "list-group-item list-group-item-action";
+      a.href = `./assignment.html?aID=${encodeURIComponent(it.aID || "")}`;
+      a.textContent = `${it.subject || ""} – ${it.title || "Assignment"}`;
+      els.aList.appendChild(a);
+    });
+  }
+
+  function filterWorksheets(list, q) {
+    if (!q) return list;
+    return list.filter((it) => {
+      const hay = [it.title, it.subject, it.chapter]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return hay.includes(q);
+    });
+  }
+
+  function renderWorksheets(list) {
+    if (list.length === 0) {
+      els.wEmpty.classList.remove("d-none");
+      return;
+    }
+    list.forEach((it) => {
+      const a = document.createElement("a");
+      a.className = "list-group-item list-group-item-action";
+      a.href = `./worksheet.html?wID=${encodeURIComponent(it.wID || "")}`;
+      a.textContent = `${it.subject || ""} – ${it.title || "Worksheet"}`;
+      els.wList.appendChild(a);
+    });
+  }
+
+  function normalizeWorksheets(input) {
+    const out = [];
+    const pushItem = (raw, subjHint) => {
+      if (!raw) return;
+      const subject = (raw.subject || subjHint || "").toString();
+      const chapter = (
+        raw.chapter ||
+        raw.chapterName ||
+        raw.topic ||
+        ""
+      ).toString();
+      const title = (
+        raw.title ||
+        raw.name ||
+        raw.worksheetTitle ||
+        raw.label ||
+        raw.file ||
+        "Worksheet"
+      ).toString();
+      const wID = String(
+        raw.wID || raw.id || raw.wid || generateWID(subject, chapter, title)
+      );
+      out.push({ subject, chapter, title, wID });
+    };
+
+    if (Array.isArray(input)) {
+      input.forEach((it) => pushItem(it));
+    } else if (input && Array.isArray(input.worksheets)) {
+      input.worksheets.forEach((it) => pushItem(it));
+    } else if (input && Array.isArray(input.items)) {
+      input.items.forEach((it) => pushItem(it));
+    } else if (input && typeof input === "object") {
+      Object.entries(input).forEach(([subj, arr]) => {
+        if (Array.isArray(arr)) arr.forEach((it) => pushItem(it, subj));
+      });
+    }
+
+    return out;
+  }
+
+  function generateWID(subject, chapter, title) {
+    const slug = (s) =>
+      String(s || "")
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9\s-]/g, "")
+        .replace(/\s+/g, "-")
+        .replace(/-+/g, "-");
+    return [slug(subject), slug(chapter), slug(title)]
+      .filter(Boolean)
+      .join("-");
+  }
+})();
+


### PR DESCRIPTION
## Summary
- Add new `search.html`/`search.js` to query assignments and worksheets separately and display results.
- Redirect navbar search to the new search page and keep the query in the URL.
- Expand navbar search input on focus with responsive styles for mobile.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaf51259b8832fa24af83f3a053b6a