### PR TITLE
Smooth fade for mobile question bar

### DIFF
--- a/frontend/assignment.css
+++ b/frontend/assignment.css
@@ -170,6 +170,8 @@ body.bg-dark { background-color: transparent !important; }
   padding: .5rem .25rem .25rem;
   gap: .5rem;
   z-index: 2;
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 30px, #000 calc(100% - 30px), transparent);
+          mask-image: linear-gradient(90deg, transparent, #000 30px, #000 calc(100% - 30px), transparent);
 }
 #mobile-qbar button {
   display: inline-block;


### PR DESCRIPTION
## Summary
- Fade mobile question bar edges using a CSS mask for a smoother look on assignment page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aaf734ec90832fa1355a09b3a6f28d