### PR TITLE
feat: render qText newlines

### DIFF
--- a/frontend/assignment.js
+++ b/frontend/assignment.js
@@ -1052,7 +1052,7 @@
       qImgDiv.style.display = "none";
       qImgDiv.innerHTML = "";
     }
-    qTextElm.textContent = question.qText;
+    qTextElm.innerHTML = escapeHtml(question.qText || "").replace(/\n/g, "<br>");
     renderMathInElement(qTextElm, katexOptions);
 
     // --- Timer control ---

--- a/frontend/bookmarks.js
+++ b/frontend/bookmarks.js
@@ -337,7 +337,7 @@
                   <i class="bi bi-x"></i>
                 </button>
               </div>
-              <p class="card-text">${escapeHtml(truncated)}</p>
+              <p class="card-text">${escapeHtml(truncated).replace(/\n/g, "<br>")}</p>
               <div class="d-flex justify-content-between align-items-center">
                 <span class="badge bg-info">${escapeHtml(
                   String(q.qType)
@@ -526,7 +526,7 @@
     if (question.qText) {
       html += `<div class="mb-3"><strong>Question:</strong><br><div class="question-text">${esc(
         question.qText
-      )}</div></div>`;
+      ).replace(/\n/g, "<br>")}</div></div>`;
     }
 
     // Question image


### PR DESCRIPTION
## Summary
- render newlines in bookmarked question previews and modal question view
- render newlines in assignment question text

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaf6c427dc832fa26495c8fe65b70f