### PR TITLE
Fix assignment data wipe on login

### DIFF
--- a/frontend/assignment.js
+++ b/frontend/assignment.js
@@ -535,6 +535,20 @@
 
     if (authSource === "server") {
       try {
+        // Fetch latest state from server and merge with any local progress
+        try {
+          const res = await authFetch(`${API_BASE}/api/state/${aID}`);
+          if (res.ok) {
+            const server = await res.json();
+            if (Array.isArray(server) && server.length) {
+              questionStates = mergeStates(server, questionStates);
+              ensureStateLength(window.displayQuestions.length);
+              questionButtons.forEach((_, i) => evaluateQuestionButtonColor(i));
+              if (currentQuestionID != null) setQuestion(currentQuestionID);
+            }
+          }
+        } catch {}
+
         if (dirty) {
           await postState(aID, questionStates);
           dirty = false;


### PR DESCRIPTION
## Summary
- Merge server state after login on the assignment page to keep existing progress
- Update question UI after login to reflect merged state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf75df084832fa97e554f125cd0c6