### PR TITLE
feat: update star toggling without rebuild

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -294,7 +294,12 @@
     )}">${escapeHtml(entry.faculty || "—")}</strong>`;
     meta.append(ch, fac);
 
-    body.append(title, meta);
+    const titleDiv = document.createElement("div");
+    titleDiv.className = "d-flex justify-content-between"
+
+    titleDiv.append(title)
+
+    body.append(titleDiv, meta);
 
     const footer = document.createElement("div");
     footer.className = "card-footer bg-transparent border-0 as-actions";
@@ -313,18 +318,19 @@
       typeof score === "number" && typeof maxScore === "number"
         ? `<span class="badge bg-primary">${score} / ${maxScore}</span>`
         : `<span class="badge bg-secondary">-</span>`;
-
+    info.append(scoreSpan);
+        
     const starBtn = document.createElement("button");
     starBtn.type = "button";
-    starBtn.className = "btn btn-link p-0 ms-auto";
-    starBtn.innerHTML = '<i class="bi bi-star"></i>';
+    starBtn.className = "btn p-0 ms-auto";
+    starBtn.innerHTML = '<i class="bi bi-star text-warning"></i>';
     starBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       const iconEl = starBtn.querySelector("i");
       toggleStar(iconEl, entry.aID);
     });
 
-    info.append(scoreSpan, starBtn);
+    titleDiv.append(starBtn)
 
     const progressWrap = document.createElement("div");
     progressWrap.className = "as-progress w-100";

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -337,6 +337,67 @@
     return card;
   }
 
+  // === Starred assignments ===
+  function ensureStarSection() {
+    let sec = document.getElementById("as-starred");
+    if (!sec) {
+      sec = document.createElement("section");
+      sec.id = "as-starred";
+      sec.className = "as-subject";
+      sec.innerHTML =
+        '<div class="as-header"><button class="btn btn-sm btn-link as-toggle text-dark-emphasis fs-5" data-bs-toggle="collapse" data-bs-target="#as-starred-collapse" aria-controls="as-starred-collapse"><i class="bi bi-chevron-right"></i><span class="me-1">Starred</span> <span class="as-count">(0)</span></button></div>' +
+        '<div id="as-starred-collapse" class="collapse show"><div class="as-grid"></div></div>';
+      els.content.prepend(sec);
+    }
+    return sec;
+  }
+
+  function updateStarSection(sec) {
+    const grid = sec.querySelector(".as-grid");
+    const count = sec.querySelector(".as-count");
+    if (count) count.textContent = `(${grid.querySelectorAll(".as-card").length})`;
+    if (grid.children.length === 0) sec.remove();
+  }
+
+  function toggleStar(icon, id) {
+    const key = "starredAssignments";
+    const raw = localStorage.getItem(key);
+    const set = new Set(raw ? JSON.parse(raw) : []);
+    const strId = String(id);
+    const card = icon.closest(".as-card");
+    if (!card) return;
+    card.dataset.starId = strId;
+
+    if (set.has(strId)) {
+      set.delete(strId);
+      localStorage.setItem(key, JSON.stringify([...set]));
+      icon.classList.remove("bi-star-fill");
+      icon.classList.add("bi-star");
+      const sec = document.getElementById("as-starred");
+      sec?.querySelector(`.as-card[data-star-id="${strId}"]`)?.remove();
+      if (sec) updateStarSection(sec);
+    } else {
+      set.add(strId);
+      localStorage.setItem(key, JSON.stringify([...set]));
+      icon.classList.add("bi-star-fill");
+      icon.classList.remove("bi-star");
+      const sec = ensureStarSection();
+      const grid = sec.querySelector(".as-grid");
+      const clone = card.cloneNode(true);
+      clone.dataset.starId = strId;
+      const cloneIcon = clone.querySelector(".bi-star, .bi-star-fill");
+      if (cloneIcon) {
+        cloneIcon.classList.add("bi-star-fill");
+        cloneIcon.classList.remove("bi-star");
+        cloneIcon.addEventListener("click", () => toggleStar(cloneIcon, strId));
+      }
+      grid.appendChild(clone);
+      updateStarSection(sec);
+    }
+  }
+
+  window.toggleStar = toggleStar;
+
   // === utils ===
   function slug(s) {
     return String(s || "")

--- a/frontend/worksheet_index.js
+++ b/frontend/worksheet_index.js
@@ -292,6 +292,67 @@
     return card;
   }
 
+  // === Starred worksheets ===
+  function ensureStarSection() {
+    let sec = document.getElementById("as-starred");
+    if (!sec) {
+      sec = document.createElement("section");
+      sec.id = "as-starred";
+      sec.className = "as-subject";
+      sec.innerHTML =
+        '<div class="as-header"><button class="btn btn-sm btn-link as-toggle text-dark-emphasis fs-5" data-bs-toggle="collapse" data-bs-target="#as-starred-collapse" aria-controls="as-starred-collapse"><i class="bi bi-chevron-right"></i><span class="me-1">Starred</span> <span class="as-count">(0)</span></button></div>' +
+        '<div id="as-starred-collapse" class="collapse show"><div class="as-grid"></div></div>';
+      els.content.prepend(sec);
+    }
+    return sec;
+  }
+
+  function updateStarSection(sec) {
+    const grid = sec.querySelector(".as-grid");
+    const count = sec.querySelector(".as-count");
+    if (count) count.textContent = `(${grid.querySelectorAll(".as-card").length})`;
+    if (grid.children.length === 0) sec.remove();
+  }
+
+  function toggleStar(icon, id) {
+    const key = "starredWorksheets";
+    const raw = localStorage.getItem(key);
+    const set = new Set(raw ? JSON.parse(raw) : []);
+    const strId = String(id);
+    const card = icon.closest(".as-card");
+    if (!card) return;
+    card.dataset.starId = strId;
+
+    if (set.has(strId)) {
+      set.delete(strId);
+      localStorage.setItem(key, JSON.stringify([...set]));
+      icon.classList.remove("bi-star-fill");
+      icon.classList.add("bi-star");
+      const sec = document.getElementById("as-starred");
+      sec?.querySelector(`.as-card[data-star-id="${strId}"]`)?.remove();
+      if (sec) updateStarSection(sec);
+    } else {
+      set.add(strId);
+      localStorage.setItem(key, JSON.stringify([...set]));
+      icon.classList.add("bi-star-fill");
+      icon.classList.remove("bi-star");
+      const sec = ensureStarSection();
+      const grid = sec.querySelector(".as-grid");
+      const clone = card.cloneNode(true);
+      clone.dataset.starId = strId;
+      const cloneIcon = clone.querySelector(".bi-star, .bi-star-fill");
+      if (cloneIcon) {
+        cloneIcon.classList.add("bi-star-fill");
+        cloneIcon.classList.remove("bi-star");
+        cloneIcon.addEventListener("click", () => toggleStar(cloneIcon, strId));
+      }
+      grid.appendChild(clone);
+      updateStarSection(sec);
+    }
+  }
+
+  window.toggleStar = toggleStar;
+
   // === Search / filter like index.js ===
   function applyFilter() {
     lastSearch = (els.search.value || "").trim();


### PR DESCRIPTION
## Summary
- update star toggling in index and worksheet list to manipulate DOM instead of rebuilding
- star icons update in place and cards are cloned into the Starred section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3a1b36f4832f8b808ec3de147b5d