### PR TITLE
Disable caching of dynamic content

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -57,6 +57,14 @@ app.options('*', corsFn);
 // ---------- Parsers ----------
 app.use(express.json());
 
+// ---------- Disable caching for dynamic content ----------
+app.use((req, res, next) => {
+  res.set('Cache-Control', 'no-store');
+  res.set('Pragma', 'no-cache');
+  res.set('Expires', '0');
+  next();
+});
+
 // ---------- SQLite ----------
 const dbPath = path.join(__dirname, 'db.sqlite');
 const db = new Database(dbPath);

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -14,5 +14,5 @@ window.authFetch = (url, opts = {}) => {
   const token = qbGetToken();
   const headers = new Headers(opts.headers || {});
   if (token) headers.set("Authorization", `Bearer ${token}`);
-  return fetch(url, { ...opts, headers });
+  return fetch(url, { cache: "no-store", ...opts, headers });
 };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -27,6 +27,14 @@ self.addEventListener('activate', event => {
 self.addEventListener('fetch', event => {
   const { request } = event;
   if (request.method !== 'GET') return;
+  const url = new URL(request.url);
+  // Skip caching for cross-origin or API requests
+  if (url.origin !== self.location.origin || url.pathname.startsWith('/api/')) {
+    event.respondWith(
+      fetch(request).catch(() => caches.match('/qbase/offline.html'))
+    );
+    return;
+  }
 
   event.respondWith(
     caches.match(request).then(cached => {


### PR DESCRIPTION
## Summary
- Send no-store caching headers for API responses
- Bypass caches in authFetch wrapper
- Update service worker to skip caching API and cross-origin requests

## Testing
- `npm test` (fails: Missing script: "test")
- `node --check backend/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68b03de1615c832fb5ab166871143b70